### PR TITLE
Ensure agent details row always displays when data exists

### DIFF
--- a/plugins/sepehr-agent-invoice/sepehr-agent-invoice.php
+++ b/plugins/sepehr-agent-invoice/sepehr-agent-invoice.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Sepehr Agent Invoice
  * Plugin URI:        https://example.com/
  * Description:       Extends Pepro Ultimate Invoice templates to include sales agent information on pre-invoices.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            Sepehr Electric
  * Author URI:        https://example.com/
  * License:           GPL-2.0-or-later
@@ -128,15 +128,18 @@ function sepehr_agent_invoice_inject_agent_details($opts, $order)
     $opts['sales_agent_address'] = $address_string;
     $opts['sales_agent_code'] = $agent_code;
 
-    $required_fields = array(
-        $opts['sales_agent_fullname'],
-        $opts['sales_agent_store'],
-        $opts['sales_agent_phone'],
-        $opts['sales_agent_address'],
-        $opts['sales_agent_code'],
+    $has_sales_agent_details = '' !== implode(
+        '',
+        array(
+            $opts['sales_agent_fullname'],
+            $opts['sales_agent_store'],
+            $opts['sales_agent_phone'],
+            $opts['sales_agent_address'],
+            $opts['sales_agent_code']
+        )
     );
 
-    if ('' !== implode('', $required_fields) && count(array_filter($required_fields)) === count($required_fields)) {
+    if ($has_sales_agent_details) {
         $opts['show_sales_agent_details'] = 'yes';
     }
 

--- a/plugins/sepehr-agent-invoice/templates/preinvoice-agent/default.cfg
+++ b/plugins/sepehr-agent-invoice/templates/preinvoice-agent/default.cfg
@@ -1,7 +1,7 @@
 /*
 Name: Default Pre-Invoice + Agent
 Designer: Sepehr Electric
-Version: 1.0.0
+Version: 1.0.1
 PDF_margin_top: 24
 PDF_margin_right: 5
 PDF_margin_bottom: 10

--- a/plugins/sepehr-agent-invoice/templates/preinvoice-agent/template.tpl
+++ b/plugins/sepehr-agent-invoice/templates/preinvoice-agent/template.tpl
@@ -3,6 +3,36 @@
     <div if="watermark" style="opacity: {{{watermark_opacity_10}}};filter: alpha(opacity={{{watermark_opacity}}});" data-opacity="{{{watermark_opacity}}}" class="watermark"></div>
     <table class="header-table" style="width: 100%; margin: 0;">
       <tr><td style="width: 1.8cm;"></td><td></td><td style="width: 4.5cm !important;"></td></tr>
+      <tr class="show_shipping_ref_id_colspan">
+        <td style="width: 1.8cm; height: 2.5cm;vertical-align: middle; padding: 0 0 4px">
+          <div class="header-item-wrapper">
+            <div class="portait">{{{trnslt__seller}}}</div>
+          </div>
+        </td>
+        <td colspan="2" style="padding: 0 4px 4px;height: 2.5cm;">
+          <div class="bordered grow header-item-data">
+            <table class="grow centered">
+              <tr>
+                <td style="width: 7cm">
+                  <span class="label">فروشنده:</span> {{{store_name}}}
+                </td>
+                <td if="show_store_national_id" style="width: 5cm">
+                  <span class="label">شناسه ملی:</span> <span class='autodir'>{{{store_national_id}}}</span></td>
+                <td if="show_store_registration_number">
+                  <span class="label">شماره ثبت:</span> <span class='autodir'>{{{store_registration_number}}}</span></td>
+                <td if="show_store_economical_number">
+                  <span class="label">شماره اقتصادی:</span> <span class='autodir'>{{{store_economical_number}}}</span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="label">نشانی شرکت:</span> {{{store_address}}}</td>
+                <td><span class="label">کدپستی:</span> <span class='autodir'>{{{store_postcode}}}</span></td>
+                <td>
+                  <span class="label">تلفن و فکس:</span> <span class='autodir'>{{{store_phone}}}</span></td>
+              </tr>
+            </table>
+          </div>
+        </td>
+      </tr>
       <tr class="">
         <td style="width: 1.8cm; height: 2.5cm;vertical-align: middle; padding: 0 0 4px">
           <div class="header-item-wrapper">


### PR DESCRIPTION
## Summary
- allow the pre-invoice sales agent block to render whenever any agent information is available so the four header sections stay visible
- bump the Sepehr Agent Invoice plugin and template versions to 1.0.1

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7bec546f0832996e9d8822caceaeb